### PR TITLE
Exporting GEnum

### DIFF
--- a/src/Accessors.hs
+++ b/src/Accessors.hs
@@ -16,6 +16,7 @@ module Accessors
        , showTree
        , showFlat
        , GLookup(..)
+       , GEnum(..)
        ) where
 
 import Accessors.Accessors

--- a/src/Accessors/Accessors.hs
+++ b/src/Accessors/Accessors.hs
@@ -23,6 +23,7 @@ module Accessors.Accessors
        , showTree
        , showFlat
        , GLookup(..)
+       , GEnum(..)
        ) where
 
 import GHC.Generics


### PR DESCRIPTION
This is useful for say, implementing missing instances at use site.
I might submit a PR adding those, but I fear I'm not experienced 
with Generics enough yet.

There's no `M1` instance, for example.